### PR TITLE
fix(android-auth): silent 401 refresh and auto-logout

### DIFF
--- a/android/app/src/main/java/cn/net/rms/chatroom/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/cn/net/rms/chatroom/data/repository/AuthRepository.kt
@@ -158,6 +158,11 @@ class AuthException(
     val isUnauthorized: Boolean = false
 ) : Exception(message)
 
+/** True when the failure is a 401 that TokenAuthenticator already handled (or tried to). */
+val Throwable.isUnauthorized: Boolean
+    get() = (this as? AuthException)?.isUnauthorized == true
+            || (this as? HttpException)?.code() == 401
+
 fun Exception.toAuthException(): AuthException {
     return when (this) {
         is UnknownHostException -> AuthException("无法连接服务器，请检查网络", isUnauthorized = false)

--- a/android/app/src/main/java/cn/net/rms/chatroom/ui/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/cn/net/rms/chatroom/ui/auth/AuthViewModel.kt
@@ -35,6 +35,23 @@ class AuthViewModel @Inject constructor(
 
     init {
         checkAuth()
+        observeTokenCleared()
+    }
+
+    /**
+     * Watch for token removal by TokenAuthenticator (e.g. refresh failed
+     * on a background request). When tokens disappear, silently transition
+     * to unauthenticated state so the user lands on the login screen.
+     */
+    private fun observeTokenCleared() {
+        viewModelScope.launch {
+            authRepository.tokenFlow.collect { token ->
+                if (token == null && _state.value.isAuthenticated) {
+                    Log.d(TAG, "Token cleared externally, transitioning to unauthenticated")
+                    _state.value = AuthState(isLoading = false, isAuthenticated = false)
+                }
+            }
+        }
     }
 
     private fun checkAuth() {
@@ -90,12 +107,7 @@ class AuthViewModel @Inject constructor(
         if (refreshToken == null) {
             Log.d(TAG, "No refresh token available, forcing re-login")
             authRepository.clearTokens()
-            _state.value = AuthState(
-                isLoading = false,
-                isAuthenticated = false,
-                token = null,
-                error = "登录已过期，请重新登录"
-            )
+            _state.value = AuthState(isLoading = false, isAuthenticated = false)
             return
         }
 
@@ -117,23 +129,13 @@ class AuthViewModel @Inject constructor(
                     .onFailure { e ->
                         Log.e(TAG, "Post-refresh verify failed", e)
                         authRepository.clearTokens()
-                        _state.value = AuthState(
-                            isLoading = false,
-                            isAuthenticated = false,
-                            token = null,
-                            error = "登录已过期，请重新登录"
-                        )
+                        _state.value = AuthState(isLoading = false, isAuthenticated = false)
                     }
             }
             .onFailure { e ->
                 Log.e(TAG, "Token refresh failed", e)
                 authRepository.clearTokens()
-                _state.value = AuthState(
-                    isLoading = false,
-                    isAuthenticated = false,
-                    token = null,
-                    error = "登录已过期，请重新登录"
-                )
+                _state.value = AuthState(isLoading = false, isAuthenticated = false)
             }
     }
 

--- a/android/app/src/main/java/cn/net/rms/chatroom/ui/main/MainViewModel.kt
+++ b/android/app/src/main/java/cn/net/rms/chatroom/ui/main/MainViewModel.kt
@@ -15,6 +15,7 @@ import cn.net.rms.chatroom.data.api.AppUpdateResponse
 import cn.net.rms.chatroom.data.model.AttachmentResponse
 import cn.net.rms.chatroom.data.manager.MentionNotificationManager
 import cn.net.rms.chatroom.data.repository.AuthRepository
+import cn.net.rms.chatroom.data.repository.isUnauthorized
 import cn.net.rms.chatroom.data.repository.BugReportRepository
 import cn.net.rms.chatroom.data.repository.ChatRepository
 import cn.net.rms.chatroom.data.repository.ReadPositionRepository
@@ -146,10 +147,8 @@ class MainViewModel @Inject constructor(
                     servers.firstOrNull()?.let { selectServer(it.id) }
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(
-                        isLoading = false,
-                        error = e.message
-                    )
+                    _state.value = _state.value.copy(isLoading = false)
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = e.message)
                 }
         }
     }
@@ -169,7 +168,7 @@ class MainViewModel @Inject constructor(
                         ?.let { selectChannel(it) }
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = e.message)
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = e.message)
                 }
         }
     }
@@ -225,10 +224,8 @@ class MainViewModel @Inject constructor(
                     _state.value = _state.value.copy(isMessagesLoading = false)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(
-                        isMessagesLoading = false,
-                        error = e.message
-                    )
+                    _state.value = _state.value.copy(isMessagesLoading = false)
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = e.message)
                 }
         }
     }
@@ -299,7 +296,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             chatRepository.sendMessage(channelId, content, attachmentIds, replyToId)
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "发送失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "发送失败: ${e.message}")
                 }
         }
     }
@@ -394,7 +391,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "创建频道失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "创建频道失败: ${e.message}")
                 }
         }
     }
@@ -414,7 +411,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "删除频道失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "删除频道失败: ${e.message}")
                 }
         }
     }
@@ -427,7 +424,7 @@ class MainViewModel @Inject constructor(
                     loadServers()
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "创建服务器失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "创建服务器失败: ${e.message}")
                 }
         }
     }
@@ -449,7 +446,7 @@ class MainViewModel @Inject constructor(
                     loadServers()
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "删除服务器失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "删除服务器失败: ${e.message}")
                 }
         }
     }
@@ -472,7 +469,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "排序失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "排序失败: ${e.message}")
                 }
         }
     }
@@ -486,7 +483,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "排序失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "排序失败: ${e.message}")
                 }
         }
     }
@@ -500,7 +497,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "创建分组失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "创建分组失败: ${e.message}")
                 }
         }
     }
@@ -514,7 +511,7 @@ class MainViewModel @Inject constructor(
                     selectServer(serverId)
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "删除分组失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "删除分组失败: ${e.message}")
                 }
         }
     }
@@ -525,7 +522,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             chatRepository.editMessage(channelId, messageId, content)
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "编辑失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "编辑失败: ${e.message}")
                 }
         }
     }
@@ -535,7 +532,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             chatRepository.deleteMessage(channelId, messageId)
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "撤回失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "撤回失败: ${e.message}")
                 }
         }
     }
@@ -554,7 +551,7 @@ class MainViewModel @Inject constructor(
                     _state.value = _state.value.copy(error = "禁言成功")
                 }
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "禁言失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "禁言失败: ${e.message}")
                 }
         }
     }
@@ -574,7 +571,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             chatRepository.addReaction(messageId, emoji)
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "添加表情失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "添加表情失败: ${e.message}")
                 }
         }
     }
@@ -583,7 +580,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             chatRepository.removeReaction(messageId, emoji)
                 .onFailure { e ->
-                    _state.value = _state.value.copy(error = "移除表情失败: ${e.message}")
+                    if (!e.isUnauthorized) _state.value = _state.value.copy(error = "移除表情失败: ${e.message}")
                 }
         }
     }

--- a/android/app/src/main/java/cn/net/rms/chatroom/ui/music/MusicViewModel.kt
+++ b/android/app/src/main/java/cn/net/rms/chatroom/ui/music/MusicViewModel.kt
@@ -16,6 +16,7 @@ import cn.net.rms.chatroom.data.model.MusicSeekRequest
 import cn.net.rms.chatroom.data.model.QueueItem
 import cn.net.rms.chatroom.data.model.Song
 import cn.net.rms.chatroom.data.repository.AuthRepository
+import cn.net.rms.chatroom.data.repository.isUnauthorized
 import cn.net.rms.chatroom.data.websocket.MusicWebSocket
 import cn.net.rms.chatroom.data.websocket.MusicWebSocketEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -372,7 +373,7 @@ class MusicViewModel @Inject constructor(
                 }
                 _state.value = newState
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "退出登录失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "退出登录失败")
             }
         }
     }
@@ -404,7 +405,7 @@ class MusicViewModel @Inject constructor(
                 _state.value = _state.value.copy(
                     searchResults = emptyList(),
                     isSearching = false,
-                    error = "搜索失败: ${e.message}"
+                    error = if (e.isUnauthorized) null else "搜索失败: ${e.message}"
                 )
             }
         }
@@ -439,7 +440,7 @@ class MusicViewModel @Inject constructor(
                 api.addToMusicQueue(getAuthHeader(), MusicQueueAddRequest(roomName, song))
                 refreshQueue(roomName)
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "添加失败: ${e.message}")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "添加失败: ${e.message}")
             }
         }
     }
@@ -451,7 +452,7 @@ class MusicViewModel @Inject constructor(
                 api.removeFromMusicQueue(getAuthHeader(), roomName, index)
                 refreshQueue(roomName)
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "删除失败: ${e.message}")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "删除失败: ${e.message}")
             }
         }
     }
@@ -463,7 +464,7 @@ class MusicViewModel @Inject constructor(
                 api.clearMusicQueue(getAuthHeader(), MusicRoomRequest(roomName))
                 refreshQueue(roomName)
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "清空失败: ${e.message}")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "清空失败: ${e.message}")
             }
         }
     }
@@ -502,7 +503,7 @@ class MusicViewModel @Inject constructor(
             } catch (e: Exception) {
                 _state.value = _state.value.copy(
                     playbackState = "idle",
-                    error = "播放失败: ${e.message}"
+                    error = if (e.isUnauthorized) null else "播放失败: ${e.message}"
                 )
             }
         }
@@ -518,7 +519,7 @@ class MusicViewModel @Inject constructor(
                     playbackState = "paused"
                 )
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "暂停失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "暂停失败")
             }
         }
     }
@@ -535,7 +536,7 @@ class MusicViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "恢复播放失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "恢复播放失败")
             }
         }
     }
@@ -547,7 +548,7 @@ class MusicViewModel @Inject constructor(
                 api.musicBotSkip(getAuthHeader(), MusicRoomRequest(roomName))
                 refreshQueue(roomName)
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "跳过失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "跳过失败")
             }
         }
     }
@@ -559,7 +560,7 @@ class MusicViewModel @Inject constructor(
                 api.musicBotPrevious(getAuthHeader(), MusicRoomRequest(roomName))
                 refreshQueue(roomName)
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "上一首失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "上一首失败")
             }
         }
     }
@@ -588,7 +589,7 @@ class MusicViewModel @Inject constructor(
                     playbackState = "idle"
                 )
             } catch (e: Exception) {
-                _state.value = _state.value.copy(error = "停止机器人失败")
+                if (!e.isUnauthorized) _state.value = _state.value.copy(error = "停止机器人失败")
             }
         }
     }


### PR DESCRIPTION
- Add Throwable.isUnauthorized extension to detect 401 errors from TokenAuthenticator
- Add observeTokenCleared() in AuthViewModel to auto-transition to unauthenticated state when tokens are cleared
- Remove error messages from token refresh failure paths
- Filter 401 errors in MainViewModel and MusicViewModel to prevent error popups
- When refresh token fails, silently redirect to login without showing error notifications